### PR TITLE
Handle SAML attributes with namespace prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,9 @@ keyval_zone    zone=saml_attrib_email:1M                state=conf.d/saml_attrib
 keyval         $cookie_auth_token $saml_attrib_email    zone=saml_attrib_email;
 ```
 
-Please note that the variable name includes the prefix `$saml_attrib_`. In the example above, the full variable name would be `$saml_attrib_email`.
+> **Note**:
+> - The NGINX variable name includes the prefix `$saml_attrib_`. In the example above, the full variable name would be `$saml_attrib_email`.  
+> - If a SAML attribute name is a namespace-qualified (like "http://schemas.example.com/identity/claims/displayname"), the system will use the last segment after the final slash ("/") as the attribute name. So, in this case, `displayname` will be correctly saved. Review your configuration if you use URI-style SAML attributes.
 
 The following keyval zones are added by default:
 

--- a/saml_sp.js
+++ b/saml_sp.js
@@ -453,6 +453,11 @@ function saveSAMLAttributes(r, root) {
         if (attrs.hasOwnProperty(attributeName)) {
             var attributeValue = attrs[attributeName];
 
+            /* If the attribute name is a URI, take only the last part after the last "/" */
+            if (attributeName.includes("http://") || attributeName.includes("https://")) {
+                attributeName = attributeName.split("/").pop();
+            }
+
             /* Save attributeName and value to the key-value store */
             try {
                 r.variables['saml_attrib_' + attributeName] = attributeValue;

--- a/saml_sp.js
+++ b/saml_sp.js
@@ -455,7 +455,7 @@ function saveSAMLAttributes(r, root) {
 
             /* If the attribute name is a URI, take only the last part after the last "/" */
             if (attributeName.includes("http://") || attributeName.includes("https://")) {
-                attributeName = attributeName.split("/").pop();
+                attributeName = attributeName.substring(attributeName.lastIndexOf('/')+1);
             }
 
             /* Save attributeName and value to the key-value store */


### PR DESCRIPTION
This commit resolves an issue when processing SAML attributes where the attribute name is provided as a URI (with namespace prefix). In the previous implementation, attribute names that were URIs caused an issue when we tried to save them as NGINX variables because NGINX variable names do not support characters like `:`, `/`, or `.`.

Now, if the attribute name is a URI, we extract only the last part after the final `/` to use as the variable name. This ensures that the variable names are always compatible with NGINX.