### PR TITLE
Improved handling of optional and mandatory elements in SAML Assertions

### DIFF
--- a/saml_sp.js
+++ b/saml_sp.js
@@ -407,7 +407,11 @@ function parseAuthnStatement(root, maxAuthenticationAge) {
     if (!root) {
         throw Error('The AuthnContext element is missing in the AuthnStatement');
     }
-    
+
+    if (!root.AuthnContextClassRef) {
+        throw Error('The AuthnContextClassRef element is missing in the AuthnContext');
+    }
+
     const authnContextClassRef = root.AuthnContextClassRef.$text;
 
     return [sessionIndex, authnContextClassRef];
@@ -417,13 +421,13 @@ function saveSAMLVariables(r, nameID, authnStatement) {
     r.variables.saml_name_id = nameID[0];
     r.variables.saml_name_id_format = nameID[1];
 
-    if (authnStatement[0]) {
-        try {
-            r.variables.saml_session_index = authnStatement[0];
-        } catch(e) {}
-    }
+    if (authnStatement) {
+        if (authnStatement[0]) {
+            try {
+                r.variables.saml_session_index = authnStatement[0];
+            } catch(e) {}
+        }
 
-    if (authnStatement[1]) {
         try {
             r.variables.saml_authn_context_class_ref = authnStatement[1];
         } catch(e) {}

--- a/saml_sp.js
+++ b/saml_sp.js
@@ -236,6 +236,14 @@ function checkIssuer(root, idpEntityId) {
  * @throws {Error} - If the SAML status is not "Success".
  */
 function verifyResponseStatus (root) {
+    if (!root) {
+        throw Error("The Status element is missing in the SAML response");
+    }
+
+    if (!root.StatusCode || !root.StatusCode.$attr$Value) {
+        throw Error("The StatusCode element is missing in the Status");
+    }
+
     const statusCode = root.StatusCode.$attr$Value;
 
     const success = "urn:oasis:names:tc:SAML:2.0:status:Success";

--- a/saml_sp.js
+++ b/saml_sp.js
@@ -452,7 +452,12 @@ function getAttributes(root) {
 }
 
 function saveSAMLAttributes(r, root) {
+    if (!root) {
+        return;
+    }
+
     let attrs = getAttributes(root.$tags$Attribute);
+
     for (var attributeName in attrs) {
         if (attrs.hasOwnProperty(attributeName)) {
             var attributeValue = attrs[attributeName];


### PR DESCRIPTION
This PR contains a series of improvements related to handling both optional and mandatory elements in SAML assertion:
1. A fix for handling the optional AuthnStatement element, which caused errors when it was missing from the SAML assertion.
2. Handling for the optional AttributeStatement, preventing errors when this element is absent from the SAML assertion.
3. Enhanced handling and error messaging for missing mandatory Status or StatusCode elements in SAML responses.
