### PR TITLE
Fix handling InclusiveNamespaces in digest calculation

### DIFF
--- a/saml_sp.js
+++ b/saml_sp.js
@@ -960,7 +960,7 @@ async function digestSAML(signature, produce) {
         throw Error(`unexpected digest transform ${transforms[1]}`);
     }
 
-    const namespaces = transformAlgs[1].InclusiveNamespaces;
+    const namespaces = transforms[1].InclusiveNamespaces;
     const prefixList = namespaces ? namespaces.$attr$PrefixList: null;
 
     const withComments = transformAlgs[1].slice(39) == 'WithComments';


### PR DESCRIPTION
The issue was caused by the incorrect handling of the `InclusiveNamespaces` element in the digest calculation process. According to the XML-DSig, the exclusive canonicalization algorithm (`XML-EXC-C14N`) allows for canonicalizing XML without including predefined namespaces unless specified through the `PrefixList` attribute.

Address issue #23